### PR TITLE
Improve cli errors

### DIFF
--- a/cli/eslint.config.js
+++ b/cli/eslint.config.js
@@ -12,7 +12,7 @@ export default antfu({
         'no-console': [
             'error',
             {
-                allow: ['info', 'warn', 'error', 'table', 'trace'],
+                allow: ['info', 'warn', 'error', 'table'],
             },
         ],
     },

--- a/cli/eslint.config.js
+++ b/cli/eslint.config.js
@@ -12,7 +12,7 @@ export default antfu({
         'no-console': [
             'error',
             {
-                allow: ['info', 'warn', 'error', 'table'],
+                allow: ['info', 'warn', 'error', 'table', 'trace'],
             },
         ],
     },

--- a/cli/index.js
+++ b/cli/index.js
@@ -39,14 +39,14 @@ yargs(hideBin(process.argv))
                     requiresArg: true,
                 });
         },
-        async argv => handleErrors(async ({ printSuccess }) => {
+        async argv => handleErrors(argv.verbose, async ({ printSuccess }) => {
             const options = {
                 userAddress: argv.userAddress,
                 userPseudonym: argv.userPseudonym,
                 teamName: argv.teamName,
             };
             console.info(`Attempting to create identity attestation for ${prettify(options)}...`);
-            const { url } = await createAttestation(await getProvider(), 'identity', options);
+            const { url } = await createAttestation(await getProvider(), 'identity', options, argv.verbose);
             printSuccess(`Successfully created new identity attestation: ${url}`);
         }),
     )
@@ -84,7 +84,7 @@ yargs(hideBin(process.argv))
                     requiresArg: true,
                 });
         },
-        async argv => handleErrors(async ({ printSuccess }) => {
+        async argv => handleErrors(argv.verbose, async ({ printSuccess }) => {
             const options = {
                 payloadId: argv.payloadId,
                 crafter: argv.crafter,
@@ -92,7 +92,7 @@ yargs(hideBin(process.argv))
                 reviewerB: argv.reviewerB,
             };
             console.info(`Attempting to create Spell attestation for ${prettify(options)}...`);
-            const { url } = await createAttestation(await getProvider(), 'spell', options);
+            const { url } = await createAttestation(await getProvider(), 'spell', options, argv.verbose);
             printSuccess(`Successfully created new Spell attestation: ${url}`);
         }),
     )
@@ -123,14 +123,14 @@ yargs(hideBin(process.argv))
                     requiresArg: true,
                 });
         },
-        async argv => handleErrors(async ({ printSuccess }) => {
+        async argv => handleErrors(argv.verbose, async ({ printSuccess }) => {
             const options = {
                 payloadId: argv.payloadId,
                 payloadAddress: argv.payloadAddress,
                 payloadHash: argv.payloadHash,
             };
             console.info(`Attempting to create deployment attestation for ${prettify(options)}...`);
-            const { url } = await createAttestation(await getProvider(), 'deployment', options);
+            const { url } = await createAttestation(await getProvider(), 'deployment', options, argv.verbose);
             printSuccess(`Successfully created new deployment attestation: ${url}`);
         }),
     )
@@ -138,7 +138,7 @@ yargs(hideBin(process.argv))
         'revoke [attestation-uid]',
         'Revoke existing attestation',
         () => {},
-        async argv => handleErrors(async ({ printSuccess }) => {
+        async argv => handleErrors(argv.verbose, async ({ printSuccess }) => {
             const attestationUid = argv.attestationUid;
             if (!attestationUid) {
                 console.info(`No [attestation-uid] provided, attempting to fetch all attestations that are possible to revoke...`);
@@ -152,7 +152,7 @@ yargs(hideBin(process.argv))
                 return;
             }
             console.info(`Attempting to revoke attestation ${attestationUid}...`);
-            const { url } = await revokeAttestation(await getProvider(), attestationUid);
+            const { url } = await revokeAttestation(await getProvider(), attestationUid, argv.verbose);
             printSuccess(`Successfully revoked attestation: ${url}`);
         }),
     )
@@ -160,7 +160,7 @@ yargs(hideBin(process.argv))
         'status [payload-id]',
         'Get status of existing spell',
         () => {},
-        async argv => handleErrors(async ({ printSuccess, printError }) => {
+        async argv => handleErrors(argv.verbose, async ({ printSuccess, printError }) => {
             const payloadId = argv.payloadId;
             if (!payloadId) {
                 console.info(`Attempting to fetch all previously attested Spells...`);
@@ -191,7 +191,7 @@ yargs(hideBin(process.argv))
         'configure [key] [value]',
         'Configure env variables',
         () => {},
-        async argv => handleErrors(async ({ printSuccess }) => {
+        async argv => handleErrors(argv.verbose, async ({ printSuccess }) => {
             if (!argv.key || !argv.value) {
                 console.info('To configure a variable, please provide its [key] and [value], for example:');
                 console.info('npx spell-attester configure RPC_URL http://...');
@@ -205,4 +205,9 @@ yargs(hideBin(process.argv))
     )
     .strictCommands()
     .demandCommand(1)
+    .option('verbose', {
+        type: 'boolean',
+        description: 'Run with verbose logging',
+        requiresArg: false,
+    })
     .parse();

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "spell-attester",
-  "version": "0.0.9",
+  "version": "0.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spell-attester",
-      "version": "0.0.9",
+      "version": "0.0.14",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@ethereum-attestation-service/eas-sdk": "^0.29.1",
+        "chalk": "^5.3.0",
         "dotenv": "^16.4.5",
         "ethers": "^5.7.2",
         "yargs": "^17.7.2"
@@ -4721,6 +4722,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/boxen/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/boxen/node_modules/type-fest": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
@@ -5037,15 +5054,11 @@
       }
     },
     "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
       "engines": {
-        "node": ">=10"
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
@@ -6630,6 +6643,22 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
@@ -9441,6 +9470,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/log-symbols/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/loupe": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
@@ -11678,6 +11722,21 @@
       },
       "bin": {
         "write-markdown": "dist/write-markdown.js"
+      }
+    },
+    "node_modules/ts-command-line-args/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/ts-essentials": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spell-attester",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "CLI for the Maker Spell Attestation contracts",
   "repository": {
     "type": "git",

--- a/cli/package.json
+++ b/cli/package.json
@@ -27,6 +27,7 @@
   "license": "GPL-3.0-or-later",
   "dependencies": {
     "@ethereum-attestation-service/eas-sdk": "^0.29.1",
+    "chalk": "^5.3.0",
     "dotenv": "^16.4.5",
     "ethers": "^5.7.2",
     "yargs": "^17.7.2"

--- a/cli/src/attestations.js
+++ b/cli/src/attestations.js
@@ -2,7 +2,7 @@ import ethers from 'ethers';
 import { NO_EXPIRATION, ZERO_ADDRESS } from '@ethereum-attestation-service/eas-sdk';
 import { getEasAttesterContract, getEasRegistryContract, getSpellAttesterContract } from './contracts.js';
 import { getConfig, getDateFromBlockNumber, getSigner } from './network.js';
-import { decodeAttestationData, encodeAttestationData } from './helpers.js';
+import { decodeAttestationData, decodeErrorMessage, encodeAttestationData } from './helpers.js';
 
 const generateAttestationUrl = async function (provider, attestationId) {
     const config = await getConfig(provider);
@@ -57,7 +57,7 @@ export const createAttestation = async function (provider, name, options) {
             url: await generateAttestationUrl(provider, attestationId),
         };
     } catch (error) {
-        throw new Error(`Attestation can not be created: ${error?.error?.reason || error?.reason || error}`);
+        throw new Error(`Attestation can not be created: ${decodeErrorMessage(error)}`);
     }
 };
 
@@ -83,7 +83,7 @@ export const revokeAttestation = async function (provider, attestationId) {
             url: await generateAttestationUrl(provider, attestationId),
         };
     } catch (error) {
-        throw new Error(`Attestation can not be revoked: ${error?.error?.reason || error?.reason}`);
+        throw new Error(`Attestation can not be revoked: ${decodeErrorMessage(error)}`);
     }
 };
 

--- a/cli/src/attestations.js
+++ b/cli/src/attestations.js
@@ -28,7 +28,7 @@ export const getAttestationData = async function (provider, attestationId) {
     };
 };
 
-export const createAttestation = async function (provider, name, options) {
+export const createAttestation = async function (provider, name, options, verbose) {
     // Get relevant data
     const spellAttester = await getSpellAttesterContract(provider);
     const schemaId = await spellAttester.schemaNameToSchemaId(ethers.utils.formatBytes32String(name));
@@ -57,11 +57,14 @@ export const createAttestation = async function (provider, name, options) {
             url: await generateAttestationUrl(provider, attestationId),
         };
     } catch (error) {
+        if (verbose) {
+            console.error(error);
+        }
         throw new Error(`Attestation can not be created: ${decodeErrorMessage(error)}`);
     }
 };
 
-export const revokeAttestation = async function (provider, attestationId) {
+export const revokeAttestation = async function (provider, attestationId, verbose) {
     // Get relevant data
     const easAttester = (await getEasAttesterContract(provider)).connect(getSigner(provider));
     const attestation = await getAttestation(provider, attestationId);
@@ -83,6 +86,9 @@ export const revokeAttestation = async function (provider, attestationId) {
             url: await generateAttestationUrl(provider, attestationId),
         };
     } catch (error) {
+        if (verbose) {
+            console.error(error);
+        }
         throw new Error(`Attestation can not be revoked: ${decodeErrorMessage(error)}`);
     }
 };

--- a/cli/src/helpers.js
+++ b/cli/src/helpers.js
@@ -1,4 +1,30 @@
+import process from 'node:process';
+import chalk from 'chalk';
 import ethers from 'ethers';
+
+export const prettyPrint = async function (fn) {
+    const printSuccess = message => console.info(chalk.bold.green(message));
+    const printError = message => console.info(chalk.bold.red(message));
+    try {
+        await fn({ printSuccess, printError });
+    } catch (error) {
+        printError(error);
+        process.exit(1);
+    }
+};
+
+export const decodeErrorMessage = function (error) {
+    const calldata = error?.error?.error?.error?.data;
+    if (calldata) {
+        const reasonString = ethers.utils.defaultAbiCoder.decode(
+            ['string'],
+            ethers.utils.hexDataSlice(calldata, 4),
+        )[0];
+        return `execution reverted: ${reasonString}`;
+    } else {
+        return error?.error?.reason || error?.reason || error;
+    }
+};
 
 export const decodeAttestationData = function (schema, attestation) {
     const optionTypes = schema.split(',').map(e => e.trim());

--- a/cli/src/helpers.js
+++ b/cli/src/helpers.js
@@ -28,7 +28,7 @@ export const decodeErrorMessage = function (error) {
             ethers.utils.hexDataSlice(calldata, 4),
         )[0];
         return `execution reverted: ${reasonString}`;
-    } catch (e) {
+    } catch {
         return error?.error?.reason || error?.reason || error;
     }
 };

--- a/cli/src/helpers.js
+++ b/cli/src/helpers.js
@@ -6,26 +6,29 @@ export const prettify = function (object) {
     return JSON.stringify(object, null, 2);
 };
 
-export const handleErrors = async function (fn) {
+export const handleErrors = async function (verbose, fn) {
     const printSuccess = message => console.info(chalk.bold.green(message));
     const printError = message => console.info(chalk.bold.red(message));
     try {
         await fn({ printSuccess, printError });
     } catch (error) {
+        if (verbose) {
+            console.error(error);
+        }
         printError(error);
         process.exit(1);
     }
 };
 
 export const decodeErrorMessage = function (error) {
-    const calldata = error?.error?.error?.error?.data;
-    if (calldata) {
+    try {
+        const calldata = error?.error?.error?.error?.data;
         const reasonString = ethers.utils.defaultAbiCoder.decode(
             ['string'],
             ethers.utils.hexDataSlice(calldata, 4),
         )[0];
         return `execution reverted: ${reasonString}`;
-    } else {
+    } catch (e) {
         return error?.error?.reason || error?.reason || error;
     }
 };

--- a/cli/src/helpers.js
+++ b/cli/src/helpers.js
@@ -2,7 +2,11 @@ import process from 'node:process';
 import chalk from 'chalk';
 import ethers from 'ethers';
 
-export const prettyPrint = async function (fn) {
+export const prettify = function (object) {
+    return JSON.stringify(object, null, 2);
+};
+
+export const handleErrors = async function (fn) {
     const printSuccess = message => console.info(chalk.bold.green(message));
     const printError = message => console.info(chalk.bold.red(message));
     try {


### PR DESCRIPTION
This PR solves a few problems with error handling inside CLI:
- It removes stack traces from thrown errors
- It parses reason strings thrown by our contracts (and no longer depends on the RPC provider to do so)
- It color-codes errors in red and success messages in green for better readability
- It adds optional `--verbose` flag to still output complete errors into the console

Current output format:
<img width="1158" alt="Screenshot 2024-07-16 at 18 19 24" src="https://github.com/user-attachments/assets/44d2339f-d12b-4dad-9e65-f669d95a85ce">
