### PR TITLE
Fix status command

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spell-attester",
-  "version": "0.0.14",
+  "version": "0.0.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spell-attester",
-      "version": "0.0.14",
+      "version": "0.0.16",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@ethereum-attestation-service/eas-sdk": "^0.29.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spell-attester",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "CLI for the Maker Spell Attestation contracts",
   "repository": {
     "type": "git",

--- a/cli/src/attestations.js
+++ b/cli/src/attestations.js
@@ -176,9 +176,9 @@ export const getSpellStatus = async function (provider, payloadId) {
     }
     const spellEvents = await getSpellEvents(provider, { payloadId });
     const allSpellMemberPseudonyms = [
-        ...spellEvents.map(a => a.data.crafter),
-        ...spellEvents.map(a => a.data.reviewerA),
-        ...spellEvents.map(a => a.data.reviewerB),
+        ...spellEvents.map(a => a.attestation.data.crafter),
+        ...spellEvents.map(a => a.attestation.data.reviewerA),
+        ...spellEvents.map(a => a.attestation.data.reviewerB),
     ];
     const uniqueSpellMemberPseudonyms = [...new Set(allSpellMemberPseudonyms)];
     const memberEvents = await Promise.all(uniqueSpellMemberPseudonyms.map((userPseudonym) => {

--- a/cli/src/attestations.test.js
+++ b/cli/src/attestations.test.js
@@ -198,7 +198,7 @@ describe('Attestation creation', () => {
         process.env.PRIVATE_KEY = undefined;
         const spellStatus = await getSpellStatus(hardhat.ethers.provider, spellAttestationData.payloadId);
         expect(spellStatus.message).to.equal('Spell is not found or not ready: "SpellAttester/spell-not-yet-reviewed"');
-        expect(spellStatus.events.length).to.be.gte(7);
+        expect(spellStatus.events.length).to.be.gte(5);
         console.table(spellStatus.events.map(formatAttestationEvent));
         // undo setup
         process.env.PRIVATE_KEY = HARDHAT_PRIVATE_KEY;


### PR DESCRIPTION
Solves a problem with status command which previously returned complete list of all Identity attestations instead returning just the ones related to the specific payloadId.